### PR TITLE
I04_1-166: timestamp in csv is now human readable

### DIFF
--- a/dls_barcode/data_store/record.py
+++ b/dls_barcode/data_store/record.py
@@ -106,12 +106,11 @@ class Record:
                       image_path=image, id=id, geometry=geometry)
 
     def to_csv_string(self):
-        """ Converts a scan record object into a string that can be stored in a file
-        and retrieved later.
+        """ Converts a scan record object into a string that can be stored in a csv file.
         """
         items = [0] * 3
         items[0] = str(self.id)
-        items[1] = str(self.timestamp)
+        items[1] = str(self._formatted_date())
         items[2] = Record.BC_SEPARATOR.join(self.barcodes)
         return Record.BC_SEPARATOR.join(items)
 

--- a/tests/unit_tests/test_dls_barcode/test_data_store/test_record.py
+++ b/tests/unit_tests/test_dls_barcode/test_data_store/test_record.py
@@ -60,6 +60,20 @@ class TestRecord(unittest.TestCase):
 
         self.assertFalse(r.any_barcode_matches([]))
 
+    def test_csv_string_contains_time_in_human_readable_format(self):
+        # Arrange
+        timestamp = 1505913516.3836024
+        human_readable_timestamp = "2017-09-20 14:18:36"
+        source_string = "f59c92c1;" + str(timestamp) + ";test.png;None;DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68"
+        record = Record.from_string(source_string)
+
+        # Act
+        csv_string = record.to_csv_string()
+
+        # Assert
+        self.assertIn(human_readable_timestamp, csv_string)
+        self.assertNotIn(str(timestamp), csv_string)
+
 
 
 


### PR DESCRIPTION
Solves ticket
-------------
Jira I04_1-166
GitHub #22 

Description of work
-------------------
csv file now contains human readable timestamp

Housekeeping
------------
- [x] Code reviewed and tidied up

To test
-------
- [x] all automated tests pass
- [x] build still works and runs


Final steps
-----------
- [x] Added work to [development release notes](https://github.com/DiamondLightSource/PuckBarcodeReader/blob/master/docs/release-notes-dev.md)
