### PR TITLE
I04_1-168: program can be launched with config file as argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test-output
 demo-resources
 *.pyc
 config.ini
+launch_barcode.bat
 
 build
 dist

--- a/build.bat
+++ b/build.bat
@@ -9,3 +9,5 @@ move dist\main.exe ..\bin\barcode.exe
 rd /S /Q build
 rd /S /Q dist
 del main.spec
+
+@echo start barcode.exe --config_file .\config.ini>"..\bin\launch_barcode.bat"

--- a/dls_barcode/main.py
+++ b/dls_barcode/main.py
@@ -9,18 +9,19 @@ from dls_util import multiprocessing_support
 
 from PyQt4 import QtGui
 from gui import DiamondBarcodeMainWindow
+import argparse
 
 # Detect if the program is running from source or has been bundled
 IS_BUNDLED = getattr(sys, 'frozen', False)
 if IS_BUNDLED:
-    CONFIG_FILE = "./config.ini"
+    DEFAULT_CONFIG_FILE = "./config.ini"
 else:
-    CONFIG_FILE = "../config.ini"
+    DEFAULT_CONFIG_FILE = "../config.ini"
 
 
-def main():
+def main(config_file):
     app = QtGui.QApplication(sys.argv)
-    ex = DiamondBarcodeMainWindow(CONFIG_FILE)
+    ex = DiamondBarcodeMainWindow(config_file)
     sys.exit(app.exec_())
 
 
@@ -30,4 +31,10 @@ if __name__ == '__main__':
         import multiprocessing
         multiprocessing.freeze_support()
 
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-cf", "--config_file", type=str, default=DEFAULT_CONFIG_FILE,
+                        help="The path of the configuration file (default=" + DEFAULT_CONFIG_FILE + ")")
+    args = parser.parse_args()
+    print("CONFIG: " + args.config_file)
+
+    main(args.config_file)

--- a/tests/system_tests/system_tests.py
+++ b/tests/system_tests/system_tests.py
@@ -36,7 +36,7 @@ TEST_OUTPUT_PATH = '../test-output/'
 
 CONFIG_FILE = "../config.ini"
 # TODO: restore the four commented lines below
-# OPTIONS = BarcodeConfig(CONFIG_FILE)
+# OPTIONS = BarcodeConfig(DEFAULT_CONFIG_FILE)
 
 # STORE = Store(OPTIONS.store_directory.value(), OPTIONS)
 

--- a/tests/system_tests/system_tests.py
+++ b/tests/system_tests/system_tests.py
@@ -36,7 +36,7 @@ TEST_OUTPUT_PATH = '../test-output/'
 
 CONFIG_FILE = "../config.ini"
 # TODO: restore the four commented lines below
-# OPTIONS = BarcodeConfig(DEFAULT_CONFIG_FILE)
+# OPTIONS = BarcodeConfig(CONFIG_FILE)
 
 # STORE = Store(OPTIONS.store_directory.value(), OPTIONS)
 


### PR DESCRIPTION
Solves ticket
-------------
Jira I04_1-168   GitHub #42 

Description of work
-------------------
The program accepts a config file path as argument. If none is provided, it will use the usual as default.
The build script creates a template launch script.

Housekeeping
------------
- [x] Code reviewed and tidied up

To test
-------
- [x] all automated tests pass
- [x] build still works and runs


Final steps
-----------
- [x] Added work to [development release notes](https://github.com/DiamondLightSource/PuckBarcodeReader/blob/master/docs/release-notes-dev.md)
