### PR TITLE
Use default Ubuntu Trusty packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,14 @@
 language: python
 sudo: required
 python:
-  - "3.5"
-
-# All of the following up until pip install -r requirements.txt is to install PyQt4
-# and was taken from https://stackoverflow.com/questions/35513019/install-pyqt4-with-python3-on-travis-ci
-before_install:
-  - sudo mkdir -p /downloads
-  - sudo chmod a+rw /downloads
-  - curl -L http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.9/sip-4.16.9.tar.gz -o /downloads/sip.tar.gz 
-  - curl -L http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.4/PyQt-x11-gpl-4.11.4.tar.gz -o /downloads/pyqt4.tar.gz
-  # Builds
-  - sudo mkdir -p /builds
-  - sudo chmod a+rw /builds
+  - "3.4"
+virtualenv:
+  system_site_packages: true
 
 install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sudo apt-get install -y libqt4-dev
-  - sudo apt-get install -y mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev
-  # Qt4
-  - pushd /builds
-  # SIP
-  - tar xzf /downloads/sip.tar.gz --keep-newer-files
-  - pushd sip-4.16.9
-  - python configure.py
-  - make
-  - sudo make install
-  - popd
-  # PyQt4
-  - tar xzf /downloads/pyqt4.tar.gz --keep-newer-files
-  - pushd PyQt-x11-gpl-4.11.4
-  - python configure.py -c --confirm-license --no-designer-plugin -e QtCore -e QtGui -e QtTest
-  - make
-  - sudo make install
-  - popd
-  # Builds Complete
-  - popd
+  - sudo apt-get install -y python3-pyqt4 python3-sip
   - pip install -r requirements.txt
+
 script:
   - nosetests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ numpy
 scipy
 opencv-python
 mock
-


### PR DESCRIPTION
Solves ticket
-------------
Travis build very slow #56

Description of work
-------------------
Changed Travis build setup to take the default Ubuntu packages.
Uses Python 3.4 instead of 3.5, PyQt4 and SIP - minor version difference.

Housekeeping
------------
- [x] Code reviewed and tidied up

To test
-------
- [x] all automated tests pass
- [x] build still works and runs


Final steps
-----------
- [x] Added work to [development release notes](https://github.com/DiamondLightSource/PuckBarcodeReader/blob/master/docs/release-notes/release-notes-dev.md)
