### PR TITLE
Backup

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -6,7 +6,7 @@ cd dls_barcode
 REM use to debug the exe file
 REM pyinstaller --onefile --icon=..\resources\icons\qr_code.ico --debug --clean main.py
 
-pyinstaller --onefile --windowed --icon="C:\Users\rqq82173\PycharmProjects\PuckBarcodeReader\resources\icons\qr_code.ico" --add-data "C:\Users\rqq82173\PycharmProjects\PuckBarcodeReader\resources; C:\Users\rqq82173\PycharmProjects\PuckBarcodeReader\bin" --clean "C:\Users\rqq82173\PycharmProjects\PuckBarcodeReader\dls_barcode\main.py"
+pyinstaller --onefile --windowed --icon="C:\Users\rqq82173\PycharmProjects\PuckBarcodeReader\resources\icons\qr_code.ico" --clean "C:\Users\rqq82173\PycharmProjects\PuckBarcodeReader\dls_barcode\main.py"
 
 move dist\main.exe ..\bin\barcode.exe
 rd /S /Q build

--- a/build.bat
+++ b/build.bat
@@ -6,11 +6,9 @@ cd dls_barcode
 REM use to debug the exe file
 REM pyinstaller --onefile --icon=..\resources\icons\qr_code.ico --debug --clean main.py
 
-pyinstaller --onefile --windowed --icon=..\resources\icons\qr_code.ico --clean main.py
+pyinstaller --onefile --windowed --icon="C:\Users\rqq82173\PycharmProjects\PuckBarcodeReader\resources\icons\qr_code.ico" --add-data "C:\Users\rqq82173\PycharmProjects\PuckBarcodeReader\resources; C:\Users\rqq82173\PycharmProjects\PuckBarcodeReader\bin" --clean "C:\Users\rqq82173\PycharmProjects\PuckBarcodeReader\dls_barcode\main.py"
 
 move dist\main.exe ..\bin\barcode.exe
 rd /S /Q build
 rd /S /Q dist
 del main.spec
-
-@echo start barcode.exe --config_file .\config.ini>"..\bin\launch_barcode.bat"

--- a/dls_barcode/config/barcode_config.py
+++ b/dls_barcode/config/barcode_config.py
@@ -44,6 +44,7 @@ class BarcodeConfig(Config):
 
         self.store_directory = add(DirectoryConfigItem, "Store Directory", default=default_store)
         self.store_capacity = add(IntConfigItem, "Results History Size", default=50)
+        self.backup_time = add(IntConfigItem, "Backup in Weeks", default=3)
 
         self.console_frame = add(BoolConfigItem, "Print Frame Summary", default=False)
         self.slot_images = add(BoolConfigItem, "Save Debug Images", default=False)

--- a/dls_barcode/config/barcode_config_dialog.py
+++ b/dls_barcode/config/barcode_config_dialog.py
@@ -55,6 +55,7 @@ class BarcodeConfigDialog(ConfigDialog):
 
         self.start_group("Store")
         self._add_control(StoreDirectoryConfigControl(cfg.store_directory))
+        add(cfg.backup_time)
         add(cfg.store_capacity)
 
         self.start_group("Debug")

--- a/dls_barcode/data_store/backup.py
+++ b/dls_barcode/data_store/backup.py
@@ -9,8 +9,6 @@ class Backup:
     Backup class maintains the short time backaup of records which is kept in the same folder as the store files.
     """
 
-    MAX_BACKUP_TIME = 6   # maximum backup time in weeks
-
     def __init__(self, directory, backup_time):
         self.comms = CommsManager(directory, "backup")
         self.backup_time = backup_time
@@ -31,7 +29,6 @@ class Backup:
         tm = time.time()
         record_time = record.timestamp
         delta = tm - record_time
-        backup_time = min(self.backup_time, self.MAX_BACKUP_TIME)
-        weeks = backup_time * 604800  # weeks in seconds
+        weeks = self.backup_time * 604800  # weeks in seconds
         return delta > weeks
 

--- a/dls_barcode/data_store/backup.py
+++ b/dls_barcode/data_store/backup.py
@@ -9,16 +9,15 @@ class Backup:
     Backup class maintains the short time backaup of records which is kept in the same folder as the store files.
     """
 
+    WEEK_IN_SECONDS = 604800
+
     def __init__(self, comms_man, backup_time):
         self._comms = comms_man
         self._backup_time = backup_time.value()
         self._records = self._comms.load_records_from_file()
-        self._truncate_record_list()
 
     def _truncate_record_list(self):
-        for record in self._records:
-            if self._is_old(record):
-                self._records.remove(record)
+        self._records = list(filter(lambda x: not self._is_old(x), self._records))
 
     def backup_records(self, to_back):
         self._records.extend(to_back)
@@ -29,6 +28,6 @@ class Backup:
         tm = time.time()
         record_time = record.timestamp
         delta = tm - record_time
-        weeks = self._backup_time * 604800  # weeks in seconds
+        weeks = self._backup_time * self.WEEK_IN_SECONDS  # weeks in seconds
         return delta > weeks
 

--- a/dls_barcode/data_store/backup.py
+++ b/dls_barcode/data_store/backup.py
@@ -9,26 +9,26 @@ class Backup:
     Backup class maintains the short time backaup of records which is kept in the same folder as the store files.
     """
 
-    def __init__(self, directory, backup_time):
-        self.comms = CommsManager(directory, "backup")
-        self.backup_time = backup_time
-        self.records = self.comms.load_records_from_file()
+    def __init__(self, comms_man, backup_time):
+        self._comms = comms_man
+        self._backup_time = backup_time.value()
+        self._records = self._comms.load_records_from_file()
         self._truncate_record_list()
 
     def _truncate_record_list(self):
-        for record in self.records:
+        for record in self._records:
             if self._is_old(record):
-                self.records.remove(record)
+                self._records.remove(record)
 
     def backup_records(self, to_back):
-        self.records.extend(to_back)
+        self._records.extend(to_back)
         self._truncate_record_list()
-        self.comms.to_csv_file(self.records)
+        self._comms.to_csv_file(self._records)
 
     def _is_old(self, record):
         tm = time.time()
         record_time = record.timestamp
         delta = tm - record_time
-        weeks = self.backup_time * 604800  # weeks in seconds
+        weeks = self._backup_time * 604800  # weeks in seconds
         return delta > weeks
 

--- a/dls_barcode/data_store/backup.py
+++ b/dls_barcode/data_store/backup.py
@@ -1,0 +1,53 @@
+import time
+
+from dls_barcode.data_store.record import Record
+from dls_util.file import FileManager
+
+
+class Backup:
+
+    def __init__(self, backup_file):
+        self._backup_file = backup_file
+        self._file_manager = FileManager()
+        self._load_records_from_file()
+
+    def _load_records_from_file(self):
+        """ Clear the current record store and load a new set of records from the specified file. """
+        self.records = []
+
+        if not self._file_manager.is_file(self._backup_file):
+            return
+
+        lines = self._file_manager.read_lines(self._backup_file)
+        for line in lines:
+            try:
+                record = Record.from_string(line)
+                self.records.append(record)
+            except Exception:
+                print("Failed to parse store Record: {}".format(line))
+
+        #self._truncate_record_list()
+
+    def _to_backup_file(self):
+        """ Save the contents of the store to the backing file
+        """
+        record_lines = [rec.to_string() + "\n" for rec in self.records]
+        self._file_manager.write_lines(self._backup_file, record_lines)
+
+    def _truncate_record_list(self):
+        for record in self.records:
+            if self._is_old(record):
+                self.records.remove(record)
+
+    def backup_records(self, to_back):
+        self.records.extend(to_back)
+        self._truncate_record_list()
+        self._to_backup_file()
+
+    def _is_old(self,record):
+        tm = time.time()
+        record_time = record.timestamp
+        delta = tm - record_time
+        weeks = 3 * 604800 #3 weeks in seconds
+        return delta > weeks
+

--- a/dls_barcode/data_store/comms_manager.py
+++ b/dls_barcode/data_store/comms_manager.py
@@ -1,0 +1,54 @@
+import os
+
+from dls_barcode.data_store.record import Record
+from dls_util.file import FileManager
+
+
+class CommsManager:
+    """ Maintains communication between store/backup and the file manager.
+    """
+
+    def __init__(self, directory, file_name):
+        self._file_manager = FileManager()
+        self._directory = directory
+        self._file_name = file_name
+
+    def load_records_from_file(self):
+        """ Clear the current record store and load a new set of records from the specified file. """
+        file = os.path.join(self._directory, self._file_name + '.txt')
+        records = []
+
+        if not self._file_manager.is_file(file):
+            return records
+
+        lines = self._file_manager.read_lines(file)
+        for line in lines:
+            try:
+                record = Record.from_string(line)
+                records.append(record)
+            except Exception:
+                print("Failed to parse store Record: {}".format(line))
+
+        return records
+
+    def to_file(self, records):
+        """ Save the contents of the store to the backing file
+        """
+        file = os.path.join(self._directory, self._file_name + '.txt')
+        record_lines = [rec.to_string() + "\n" for rec in records]
+        self._file_manager.write_lines(file, record_lines)
+
+    def to_csv_file(self, records):
+        """ Save the contents of the store to the backing csv file
+        """
+        csv_file = os.path.join(self._directory, self._file_name + ".csv")
+        record_lines = [rec.to_csv_string() + "\n" for rec in records]
+        self._file_manager.write_lines(csv_file, record_lines)
+
+    def make_img_dir(self, img_dir):
+        if not self._file_manager.is_dir(img_dir):
+            self._file_manager.make_dir(img_dir)
+
+    def remove_img_file(self, record):
+        if self._file_manager.is_file(record.image_path):
+            self._file_manager.remove(record.image_path)

--- a/dls_barcode/data_store/comms_manager.py
+++ b/dls_barcode/data_store/comms_manager.py
@@ -10,7 +10,7 @@ class CommsManager:
 
     def __init__(self, directory, file_name):
         self._file_manager = FileManager()
-        self._directory = directory
+        self._directory = directory.value()
         self._file_name = file_name
 
     def load_records_from_file(self):
@@ -45,9 +45,11 @@ class CommsManager:
         record_lines = [rec.to_csv_string() + "\n" for rec in records]
         self._file_manager.write_lines(csv_file, record_lines)
 
-    def make_img_dir(self, img_dir):
+    def make_img_dir(self):
+        img_dir = os.path.join(self._directory, "img_dir")
         if not self._file_manager.is_dir(img_dir):
             self._file_manager.make_dir(img_dir)
+        return img_dir
 
     def remove_img_file(self, record):
         if self._file_manager.is_file(record.image_path):

--- a/dls_barcode/data_store/record.py
+++ b/dls_barcode/data_store/record.py
@@ -162,3 +162,4 @@ class Record:
         """
         return datetime.datetime.fromtimestamp(self.timestamp).strftime(Record.DATE_FORMAT)
 
+

--- a/dls_barcode/data_store/store.py
+++ b/dls_barcode/data_store/store.py
@@ -1,8 +1,6 @@
 import uuid
 import os
 
-from dls_barcode.data_store.backup import Backup
-from dls_barcode.data_store.comms_manager import CommsManager
 from .record import Record
 
 
@@ -13,15 +11,13 @@ class Store:
     """
     MIN_STORE_CAPACITY = 2
 
-    def __init__(self, directory, store_capacity, backup_time):
+    def __init__(self, comms_manager, backup, store_capacity):
         """ Initializes a new instance of Store.
         """
         self._store_capacity = store_capacity
-        self._backup = Backup(directory, backup_time)
-        self._comms_manager = CommsManager(directory, "store")
-        self._img_dir = os.path.join(directory, "img_dir")
-        self._comms_manager.make_img_dir(self._img_dir)
-
+        self._backup = backup
+        self._comms_manager = comms_manager
+        self._img_dir = self._comms_manager.make_img_dir()
         self.records = self._comms_manager.load_records_from_file()
         self._truncate_record_list()
         self._sort_records()

--- a/dls_barcode/data_store/store.py
+++ b/dls_barcode/data_store/store.py
@@ -2,48 +2,29 @@ import uuid
 import os
 
 from dls_barcode.data_store.backup import Backup
-from dls_util.file import FileManager
+from dls_barcode.data_store.comms_manager import CommsManager
 from .record import Record
 
 
 class Store:
+
     """ Maintains a list of records of previous barcodes scans. Any changes (additions
     or deletions) are automatically written to the backing file.
     """
-    def __init__(self, directory, store_capacity):
+    MIN_STORE_CAPACITY = 2
+
+    def __init__(self, directory, store_capacity, backup_time):
         """ Initializes a new instance of Store.
         """
         self._store_capacity = store_capacity
-        self._directory = directory
-        self._file_manager = FileManager()
-        self._file = os.path.join(directory, "store.txt")
-        self._csv_file = os.path.join(directory, "store.csv")
-        self._backup = Backup(os.path.join(directory, "backup.txt"))
+        self._backup = Backup(directory, backup_time)
+        self._comms_manager = CommsManager(directory, "store")
         self._img_dir = os.path.join(directory, "img_dir")
+        self._comms_manager.make_img_dir(self._img_dir)
 
-        if not self._file_manager.is_dir(self._img_dir):
-            self._file_manager.make_dir(self._img_dir)
-
-        self.records = []
-        self._load_records_from_file()
-        self._sort_records()
-
-    def _load_records_from_file(self):
-        """ Clear the current record store and load a new set of records from the specified file. """
-        self.records = []
-
-        if not self._file_manager.is_file(self._file):
-            return
-
-        lines = self._file_manager.read_lines(self._file)
-        for line in lines:
-            try:
-                record = Record.from_string(line)
-                self.records.append(record)
-            except Exception:
-                print("Failed to parse store Record: {}".format(line))
-
+        self.records = self._comms_manager.load_records_from_file()
         self._truncate_record_list()
+        self._sort_records()
 
     def size(self):
         """ Returns the number of records in the store
@@ -82,8 +63,7 @@ class Store:
         """
         for record in records_to_delete:
             self.records.remove(record)
-            if self._file_manager.is_file(record.image_path):
-                self._file_manager.remove(record.image_path)
+            self._comms_manager.remove_img_file(record)
 
         self._process_change()
 
@@ -91,8 +71,8 @@ class Store:
         self._backup.backup_records(records_to_backup)
 
     def _truncate_record_list(self):
-        min_store_capacity = 2
-        actual_store_capacity = max(self._store_capacity.value(), min_store_capacity)
+
+        actual_store_capacity = max(self._store_capacity.value(), self.MIN_STORE_CAPACITY)
 
         if len(self.records) > actual_store_capacity:
             to_delete = self.records[actual_store_capacity:]
@@ -104,26 +84,13 @@ class Store:
         """
         self._sort_records()
         self._truncate_record_list()
-        self._to_file()
-        self._to_csv_file()
+        self._comms_manager.to_file(self.records)
+        self._comms_manager.to_csv_file(self.records)
 
     def _sort_records(self):
         """ Sort the records in descending date order (most recent first).
         """
         self.records.sort(reverse=True, key=lambda record: record.timestamp)
-
-    def _to_file(self):
-        """ Save the contents of the store to the backing file
-        """
-        record_lines = [rec.to_string() + "\n" for rec in self.records]
-        self._file_manager.write_lines(self._file, record_lines)
-
-    def _to_csv_file(self):
-        """ Save the contents of the store to the backing csv file
-        """
-        record_lines = [rec.to_csv_string() + "\n" for rec in self.records]
-        self._file_manager.write_lines(self._csv_file, record_lines)
-
 
     def _merge_holder_image_into_pins_image(self, holder_img, pins_img):
         factor = 0.22 * pins_img.width / holder_img.width

--- a/dls_barcode/data_store/store.py
+++ b/dls_barcode/data_store/store.py
@@ -16,6 +16,7 @@ class Store:
         self._file_manager = file_manager
         self._file = os.path.join(directory, "store.txt")
         self._csv_file = os.path.join(directory, "store.csv")
+        self._backup_csv_file = os.path.join(directory, "backup.csv")
         self._img_dir = os.path.join(directory, "img_dir")
 
         if not self._file_manager.is_dir(self._img_dir):
@@ -84,12 +85,16 @@ class Store:
 
         self._process_change()
 
+    def backup_records(self, records_to_back_up):
+        self._to_backup_csv_file(records_to_back_up)
+
     def _truncate_record_list(self):
         min_store_capacity = 2
         actual_store_capacity = max(self._store_capacity.value(), min_store_capacity)
 
         if len(self.records) > actual_store_capacity:
             to_delete = self.records[actual_store_capacity:]
+            self.backup_records(to_delete)
             self.delete_records(to_delete)
 
     def _process_change(self):
@@ -116,6 +121,12 @@ class Store:
         """
         record_lines = [rec.to_csv_string() + "\n" for rec in self.records]
         self._file_manager.write_lines(self._csv_file, record_lines)
+
+    def _to_backup_csv_file(self, records):
+        """ Save the contents of the store to the backup csv file
+        """
+        record_lines = [rec.to_csv_string() + "\n" for rec in records]
+        self._file_manager.write_lines(self._backup_csv_file, record_lines)
 
     def _merge_holder_image_into_pins_image(self, holder_img, pins_img):
         factor = 0.22 * pins_img.width / holder_img.width

--- a/dls_barcode/data_store/store_manager.py
+++ b/dls_barcode/data_store/store_manager.py
@@ -1,0 +1,31 @@
+from dls_barcode.data_store import Store
+from dls_barcode.data_store.backup import Backup
+from dls_barcode.data_store.comms_manager import CommsManager
+
+
+class StoreManager:
+
+    def __init__(self, directory, store_capacity, backup_time):
+        self._store_capacity = store_capacity
+        self._directory = directory
+        self._backup_time = backup_time
+
+    def create_store(self):
+        comms_manager = self._create_store_comms_manager()
+        backup_comms_manager = self._create_backup_comms_manager()
+        backup = self._create_backup(backup_comms_manager)
+        return Store(comms_manager, backup, self._store_capacity)
+
+    def _create_store_comms_manager(self):
+        return CommsManager(self._directory, "store")
+
+    def _create_backup(self, backup_comms_manager):
+        return Backup(backup_comms_manager, self._backup_time)
+
+    def _create_backup_comms_manager(self):
+        return CommsManager(self._directory, "backup")
+
+
+
+
+

--- a/dls_barcode/gui/image_widget.py
+++ b/dls_barcode/gui/image_widget.py
@@ -15,5 +15,6 @@ class ImageWidget(QLabel):
     def eventFilter(self, source, event):
         if source is self and event.type() == QtCore.QEvent.Resize:
             ma = self.pixmap()
-            self.setPixmap(ma.scaled(self.size(), QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation))
+            if ma is not None:
+                self.setPixmap(ma.scaled(self.size(), QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation))
         return QtWidgets.QWidget.eventFilter(self, source, event)

--- a/dls_barcode/gui/record_table.py
+++ b/dls_barcode/gui/record_table.py
@@ -135,7 +135,9 @@ class ScanRecordTable(QGroupBox):
                 record = self._store.get_record(index)
                 records_to_delete.append(record)
 
+            self._store.backup_records(records_to_delete)
             self._store.delete_records(records_to_delete)
+
             self._load_store_records()
 
     def is_latest_holder_barcode(self, holder_barcode):

--- a/dls_barcode/gui/record_table.py
+++ b/dls_barcode/gui/record_table.py
@@ -22,7 +22,7 @@ class ScanRecordTable(QGroupBox):
         super(ScanRecordTable, self).__init__()
 
         # Read the store from file
-        self._store = Store(options.store_directory.value(), options.store_capacity, FileManager())
+        self._store = Store(options.store_directory.value(), options.store_capacity)
         self._options = options
 
         self._barcodeTable = barcode_table
@@ -115,7 +115,7 @@ class ScanRecordTable(QGroupBox):
             self._imageFrame.display_puck_image(marked_image)
         except IndexError:
             self._barcodeTable.clear()
-            self._imageFrame.clear_frame("Record table empty\nNothing to display")
+#            self._imageFrame.clear_frame("Record table empty\nNothing to display")
 
     def _delete_selected_records(self):
         """ Called when the 'Delete' button is pressed. Deletes all of the selected records

--- a/dls_barcode/gui/record_table.py
+++ b/dls_barcode/gui/record_table.py
@@ -5,6 +5,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QGroupBox, QVBoxLayout, QHBoxLayout, QTableWidget, QMessageBox
 
 from dls_barcode.data_store import Store
+from dls_barcode.data_store.store_manager import StoreManager
 from dls_util.file import FileManager
 
 # todo: allow delete key to be used for deletion
@@ -22,7 +23,7 @@ class ScanRecordTable(QGroupBox):
         super(ScanRecordTable, self).__init__()
 
         # Read the store from file
-        self._store = Store(options.store_directory.value(), options.store_capacity, 3)#options.backup_time
+        self._store = StoreManager(options.store_directory, options.store_capacity, options.backup_time).create_store()
         self._options = options
 
         self._barcodeTable = barcode_table

--- a/dls_barcode/gui/record_table.py
+++ b/dls_barcode/gui/record_table.py
@@ -22,7 +22,7 @@ class ScanRecordTable(QGroupBox):
         super(ScanRecordTable, self).__init__()
 
         # Read the store from file
-        self._store = Store(options.store_directory.value(), options.store_capacity)
+        self._store = Store(options.store_directory.value(), options.store_capacity, 3)#options.backup_time
         self._options = options
 
         self._barcodeTable = barcode_table

--- a/dls_util/file/file_manager.py
+++ b/dls_util/file/file_manager.py
@@ -14,6 +14,11 @@ class FileManager:
         with open(file_path, 'w') as file:
             file.writelines(lines)
 
+    def append_lines(self, file_path, lines):
+        """Calls file.writelines, so doesn't append any new line characters"""
+        with open(file_path, 'a') as file:
+            file.writelines(lines)
+
     def is_file(self, path):
         return os.path.isfile(path)
 

--- a/docs/code.md
+++ b/docs/code.md
@@ -17,10 +17,13 @@ The following steps will help you prepare an appropriate Python environment to r
     * PyQt5
     
 * All of these packages can be installed using `pip`. To do this:
-    * Open cmd.exe (being sure to ‘Run as Administrator’)
+    * Create a new virtual environment eg.`python3 -m venv my-env`
+    * activate the environment - run `my-env\Scripts\activate.bat`
     * Upgrade pip by typing `pip install –-upgrade pip`
+    * Install all required packages using pip:
     * Install pyperclip by typing `pip install pyperclip`
     * Install enum by typing `pip install enum` [only if using Python 2.7]
+    * Similarly install scipy, numpy, PyQt5 and opencv-python
 
 NOTE: there is a requirements.txt file that was created for use by the CI server Travis. It contains all of the above dependencies except for enum.
     
@@ -44,18 +47,13 @@ Creating a Self-Contained Executable
 ====================================
 A Python package called [PyInstaller](http://www.pyinstaller.org/) can be used to create a stand-alone windows executable (.exe) file.
 
-Install PyInstaller with `pip install pyinstaller`. Make sure that the correct version of Python is referenced in your system path.
+Activate your virtual environment (e.g.run in command line C:\Users\rqq82173\PycharmProjects\python_environments\barcode_qt5\Scripts\activate.bat) 
+Install PyInstaller with `pip install pyinstaller` (if it is not installed yet).
 
-To create the executable file, run the `build.bat` file. This will create the file `bin\barcode.exe`. This will be fairly large (~40 MB). If everything has worked correctly, this single file will be all that is needed to run the barcode scanner application.
-
-Troubles creating Executable
-
-Whe the path to Python on Pyinstaller contains spaces there an error [failed to create process](https://stackoverflow.com/questions/31808180/installing-pyinstaller-via-pip-leads-to-failed-to-create-process/34546220#34546220) occures. 
-To get around the porblem call script pyinstaller-script.py.
-For example: "C:\Users\Urszula Neuman\AppData\Local\Programs\Python\Python35\python.exe" "C:\Users\Urszula Neuman\AppData\Local\Programs\Python\Python35\Scripts\pyinstaller-script.py" main.py
-The result exec file is created in subdirectrory called dist.
-
-NOTE: when creating the executable on a 64bit machine (using Python 3.5.1 32bit) you might get the error ‘No module named pywintypes’. To fix this, try `pip install pypiwin32`.
+To create the executable file, run the `build.bat` file. This will create the file `bin\barcode.exe`. This will be fairly large (~40 MB). 
+'build.bat' includes hardcoded paths to the main file and the icon. This needs to be updated accordingly.
+Once .exe file is created add 'resources' folder to th bin folder (resources include the icon and the shape patter). 
+Zip the bin folder and add it to release files.
 
 Continuous Integration
 ======================

--- a/tests/system_tests/test_unipuck_scan.py
+++ b/tests/system_tests/test_unipuck_scan.py
@@ -2,6 +2,7 @@ import os, shutil
 
 from dls_barcode.config.barcode_config import BarcodeConfig
 from dls_barcode.data_store import Store
+from dls_barcode.data_store.store_manager import StoreManager
 from dls_barcode.scan import GeometryScanner
 from dls_util.image import Image
 from dls_util.file import FileManager
@@ -15,11 +16,11 @@ FILE_MANAGER = FileManager()
 OPTIONS = BarcodeConfig(CONFIG_FILE, FILE_MANAGER)
 
 # Clear store before creating a new one
-store_dir = OPTIONS.store_directory.value()
+store_dir = OPTIONS.store_directory
 if os.path.isdir(store_dir):
     shutil.rmtree(store_dir)
 
-STORE = Store(store_dir, OPTIONS.store_capacity, FILE_MANAGER)
+STORE = StoreManager(store_dir, OPTIONS.store_capacity, OPTIONS.backup_time).create_store()
 
 
 def test_generator():

--- a/tests/system_tests/test_unipuck_scan.py
+++ b/tests/system_tests/test_unipuck_scan.py
@@ -17,8 +17,8 @@ OPTIONS = BarcodeConfig(CONFIG_FILE, FILE_MANAGER)
 
 # Clear store before creating a new one
 store_dir = OPTIONS.store_directory
-if os.path.isdir(store_dir):
-    shutil.rmtree(store_dir)
+if os.path.isdir(store_dir.value()):
+    shutil.rmtree(store_dir.value())
 
 STORE = StoreManager(store_dir, OPTIONS.store_capacity, OPTIONS.backup_time).create_store()
 

--- a/tests/system_tests/test_unipuck_scan_locator.py
+++ b/tests/system_tests/test_unipuck_scan_locator.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from dls_barcode.config.barcode_config import BarcodeConfig
 from dls_barcode.data_store import Store
+from dls_barcode.data_store.store_manager import StoreManager
 from dls_barcode.geometry.unipuck import Unipuck
 from dls_barcode.scan import GeometryScanner
 from dls_util import Color
@@ -22,11 +23,11 @@ FILE_MANAGER = FileManager()
 OPTIONS = BarcodeConfig(CONFIG_FILE, FILE_MANAGER)
 
 # Clear store before creating a new one
-store_dir = OPTIONS.store_directory.value()
+store_dir = OPTIONS.store_directory
 if os.path.isdir(store_dir):
     shutil.rmtree(store_dir)
 
-STORE = Store(store_dir, OPTIONS.store_capacity, FILE_MANAGER)
+STORE = StoreManager(store_dir, OPTIONS.store_capacity, OPTIONS.backup_time).create_store()
 
 def test_generator():
     TEST_CASES = generate_test_cases()

--- a/tests/system_tests/test_unipuck_scan_locator.py
+++ b/tests/system_tests/test_unipuck_scan_locator.py
@@ -24,8 +24,8 @@ OPTIONS = BarcodeConfig(CONFIG_FILE, FILE_MANAGER)
 
 # Clear store before creating a new one
 store_dir = OPTIONS.store_directory
-if os.path.isdir(store_dir):
-    shutil.rmtree(store_dir)
+if os.path.isdir(store_dir.value()):
+    shutil.rmtree(store_dir.value())
 
 STORE = StoreManager(store_dir, OPTIONS.store_capacity, OPTIONS.backup_time).create_store()
 

--- a/tests/unit_tests/test_dls_barcode/test_data_store/test_backup.py
+++ b/tests/unit_tests/test_dls_barcode/test_data_store/test_backup.py
@@ -1,0 +1,112 @@
+import unittest
+
+import time
+from mock import MagicMock
+
+from dls_barcode.data_store.backup import Backup
+from dls_barcode.data_store.record import Record
+
+ID0 = "id0"
+ID1 = "id1"
+ID2 = "id2"
+ID3 = "id3"
+
+class TestBackup(unittest.TestCase):
+
+    def setUp(self):
+        self.comms_man = MagicMock()
+        self.backup_time = MagicMock()
+        self.backup_time.value.return_value = 3
+
+    def test_truncate_removes_all_old_records(self):
+        # Arrange
+        records = self._get_records()
+        self.comms_man.load_records_from_file.return_value = records
+
+        # Act
+        backup = Backup(self.comms_man, self.backup_time)
+        orig_size = len(backup._records)
+        backup._truncate_record_list()
+
+        # Assert
+        new_size = len(backup._records)
+        self.assertNotEqual(orig_size, new_size)
+        self.assertEqual(new_size, 0)
+
+    def test_backup_records_adds_new_records_to_existing_list(self):
+        # Arrange
+        records = self._get_records()
+        self.comms_man.load_records_from_file.return_value = records
+
+        # Act
+        backup = Backup(self.comms_man, self.backup_time)
+        org_size = len(backup._records)
+        backup._truncate_record_list = MagicMock() #mute truncate for the test
+        backup.backup_records(records)
+
+        # Assert
+        self.assertEqual(len(backup._records), 2*org_size)
+
+    def test_backup_records_removes_old_records_when_its_called(self):
+        # Arrange
+        records = self._get_records()
+        self.comms_man.load_records_from_file.return_value = records
+
+        # Act
+        backup = Backup(self.comms_man, self.backup_time)
+        backup.backup_records(records)
+
+        # Assert
+        self.assertEqual(len(backup._records), 0)
+
+    def test_backup_records_to_csv_file(self):
+        #Arrange
+        self.comms_man.to_csv_file = MagicMock()
+        backup = Backup(self.comms_man, self.backup_time)
+
+        # Act
+        backup.backup_records([])
+
+        #Assert
+        self.comms_man.to_csv_file.assert_called_once()
+
+    def test_is_old_returns_true_for_records_older_than_assumed_number_of_weeks(self):
+        # Arrange
+        weeks = self.backup_time.value.return_value
+        timestamp = str(time.time() - 604800 * (weeks + 1))
+        rec_string = "f59c92c1;" + timestamp + ";test.png;None;ABCDE123,ABCDE123;1569:1106:70-2307:1073:68-1944:1071:68"
+        record = Record.from_string(rec_string)
+
+        # Act
+        backup = Backup(self.comms_man, self.backup_time)
+
+        # Assert
+        self.assertTrue(backup._is_old(record))
+
+    def test_is_old_returns_false_for_records_younger_than_assumed_number_of_weeks(self):
+        # Arrange
+        weeks = self.backup_time.value.return_value
+        timestamp = str(time.time() - 604800 * (weeks - 1))
+        rec_string = "f59c92c1;"+timestamp+";test.png;None;ABCDE123,ABCDE123;1569:1106:70-2307:1073:68-1944:1071:68"
+        record = Record.from_string(rec_string)
+
+        # Act
+        backup = Backup(self.comms_man, self.backup_time)
+
+        # Assert
+        self.assertFalse(backup._is_old(record))
+
+    def _get_record_strings(self):
+        str_rep = list()
+        str_rep.append(ID0 + ";1494238923.0;test" + ID0 + ".png;None;DLSL-001,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
+        str_rep.append(ID1 + ";1494238922.0;test" + ID1 + ".png;None;DLSL-002,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
+        str_rep.append(ID2 + ";1494238921.0;test" + ID2 + ".png;None;DLSL-003,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
+        str_rep.append(ID3 + ";1494238920.0;test" + ID3 + ".png;None;DLSL-004,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
+        return str_rep
+
+    def _get_records(self):
+        strings = self._get_record_strings()
+        rep = list()
+        for str in strings:
+            rep.append(Record.from_string(str))
+        return rep

--- a/tests/unit_tests/test_dls_barcode/test_data_store/test_backup.py
+++ b/tests/unit_tests/test_dls_barcode/test_data_store/test_backup.py
@@ -14,7 +14,7 @@ class TestBackup(unittest.TestCase):
         WEEK_IN_SECONDS = 604800
         self.backup_time.value.return_value = weeks
         record_one = MagicMock(timestamp=time.time() - (weeks-1)*WEEK_IN_SECONDS)
-        record_two = MagicMock(timestamp=time.time() - weeks*WEEK_IN_SECONDS)
+        record_two = MagicMock(timestamp=time.time() - (weeks-2)*WEEK_IN_SECONDS)
         record_three = MagicMock(timestamp=time.time() - (weeks+1)*WEEK_IN_SECONDS)
         record_three.to_csv_string.return_value = 'csv_string_three'
         record_three.to_string.return_value = 'string_three'

--- a/tests/unit_tests/test_dls_barcode/test_data_store/test_backup.py
+++ b/tests/unit_tests/test_dls_barcode/test_data_store/test_backup.py
@@ -4,24 +4,25 @@ import time
 from mock import MagicMock
 
 from dls_barcode.data_store.backup import Backup
-from dls_barcode.data_store.record import Record
-
-ID0 = "id0"
-ID1 = "id1"
-ID2 = "id2"
-ID3 = "id3"
 
 class TestBackup(unittest.TestCase):
 
     def setUp(self):
         self.comms_man = MagicMock()
         self.backup_time = MagicMock()
-        self.backup_time.value.return_value = 3
+        weeks = 3
+        WEEK_IN_SECONDS = 604800
+        self.backup_time.value.return_value = weeks
+        record_one = MagicMock(timestamp=time.time() - (weeks-1)*WEEK_IN_SECONDS)
+        record_two = MagicMock(timestamp=time.time() - weeks*WEEK_IN_SECONDS)
+        record_three = MagicMock(timestamp=time.time() - (weeks+1)*WEEK_IN_SECONDS)
+        record_three.to_csv_string.return_value = 'csv_string_three'
+        record_three.to_string.return_value = 'string_three'
+        self.records = [record_one, record_two, record_three]
 
     def test_truncate_removes_all_old_records(self):
         # Arrange
-        records = self._get_records()
-        self.comms_man.load_records_from_file.return_value = records
+        self.comms_man.load_records_from_file.return_value = self.records
 
         # Act
         backup = Backup(self.comms_man, self.backup_time)
@@ -31,33 +32,29 @@ class TestBackup(unittest.TestCase):
         # Assert
         new_size = len(backup._records)
         self.assertNotEqual(orig_size, new_size)
-        self.assertEqual(new_size, 0)
+        self.assertEqual(new_size, 2)
 
     def test_backup_records_adds_new_records_to_existing_list(self):
         # Arrange
-        records = self._get_records()
-        self.comms_man.load_records_from_file.return_value = records
+        self.comms_man.load_records_from_file.return_value = self.records
 
         # Act
         backup = Backup(self.comms_man, self.backup_time)
-        org_size = len(backup._records)
-        backup._truncate_record_list = MagicMock() #mute truncate for the test
-        backup.backup_records(records)
+        backup.backup_records(self.records)
 
         # Assert
-        self.assertEqual(len(backup._records), 2*org_size)
+        self.assertEqual(len(backup._records), 4) #old truncated
 
-    def test_backup_records_removes_old_records_when_its_called(self):
+    def test_backup_records_removes_old_records_from_the_passed_when_its_called(self):
         # Arrange
-        records = self._get_records()
-        self.comms_man.load_records_from_file.return_value = records
+        self.comms_man.load_records_from_file.return_value = []
 
         # Act
         backup = Backup(self.comms_man, self.backup_time)
-        backup.backup_records(records)
+        backup.backup_records(self.records)
 
         # Assert
-        self.assertEqual(len(backup._records), 0)
+        self.assertEqual(len(backup._records), 2)
 
     def test_backup_records_to_csv_file(self):
         #Arrange
@@ -72,10 +69,7 @@ class TestBackup(unittest.TestCase):
 
     def test_is_old_returns_true_for_records_older_than_assumed_number_of_weeks(self):
         # Arrange
-        weeks = self.backup_time.value.return_value
-        timestamp = str(time.time() - 604800 * (weeks + 1))
-        rec_string = "f59c92c1;" + timestamp + ";test.png;None;ABCDE123,ABCDE123;1569:1106:70-2307:1073:68-1944:1071:68"
-        record = Record.from_string(rec_string)
+        record = self.records[2]
 
         # Act
         backup = Backup(self.comms_man, self.backup_time)
@@ -85,28 +79,10 @@ class TestBackup(unittest.TestCase):
 
     def test_is_old_returns_false_for_records_younger_than_assumed_number_of_weeks(self):
         # Arrange
-        weeks = self.backup_time.value.return_value
-        timestamp = str(time.time() - 604800 * (weeks - 1))
-        rec_string = "f59c92c1;"+timestamp+";test.png;None;ABCDE123,ABCDE123;1569:1106:70-2307:1073:68-1944:1071:68"
-        record = Record.from_string(rec_string)
+        record = self.records[0]
 
         # Act
         backup = Backup(self.comms_man, self.backup_time)
 
         # Assert
         self.assertFalse(backup._is_old(record))
-
-    def _get_record_strings(self):
-        str_rep = list()
-        str_rep.append(ID0 + ";1494238923.0;test" + ID0 + ".png;None;DLSL-001,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
-        str_rep.append(ID1 + ";1494238922.0;test" + ID1 + ".png;None;DLSL-002,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
-        str_rep.append(ID2 + ";1494238921.0;test" + ID2 + ".png;None;DLSL-003,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
-        str_rep.append(ID3 + ";1494238920.0;test" + ID3 + ".png;None;DLSL-004,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
-        return str_rep
-
-    def _get_records(self):
-        strings = self._get_record_strings()
-        rep = list()
-        for str in strings:
-            rep.append(Record.from_string(str))
-        return rep

--- a/tests/unit_tests/test_dls_barcode/test_data_store/test_comms_manager.py
+++ b/tests/unit_tests/test_dls_barcode/test_data_store/test_comms_manager.py
@@ -1,0 +1,152 @@
+import unittest
+
+import os
+from mock import MagicMock
+
+from dls_barcode.data_store.comms_manager import CommsManager
+from dls_barcode.data_store.record import Record
+
+ID0 = "id0"
+ID1 = "id1"
+ID2 = "id2"
+ID3 = "id3"
+
+
+class TestCommsManager(unittest.TestCase):
+
+    def setUp(self):
+        self.directory = MagicMock()
+        self.directory.value.return_value = 'dir'
+        self.file_name = 'test'
+
+    def test_load_records_from_file_returns_empty_record_list_when_no_file(self):
+        cm = CommsManager(self.directory, self.file_name)
+        records = cm.load_records_from_file()
+
+        self.assertEqual(len(records), 0)
+
+    def test_load_record_skip_invalid_lines(self):
+        # Arrange
+        cm = CommsManager(self.directory, self.file_name)
+        cm._file_manager = MagicMock()
+        cm._file_manager.read_lines.return_value = self._invalid_record_strings()
+
+        # Act
+        records = cm.load_records_from_file()
+
+        # Assert
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0].id, ID0)
+        self.assertEqual(records[1].id, ID2)
+
+    def test_to_file_stores_records_in_file(self):
+        # Arrange
+        cm = CommsManager(self.directory, self.file_name)
+        cm._file_manager = MagicMock()
+        file_name = os.path.join(self.directory.value.return_value, self.file_name + ".txt")
+        records = self._get_records()
+
+        # Act
+        cm.to_file(records)
+
+        # Assert
+        ((filename_used, record_lines_used), kwargs) = cm._file_manager.write_lines.call_args_list[0]
+        self.assertIn(file_name, filename_used)
+        for r, l in zip(records, record_lines_used):
+            self.assertIn(r.to_string(), l)
+
+    def test_to_file_csv_store_in_csv_file(self):
+        # Arrange
+        cm = CommsManager(self.directory, self.file_name)
+        cm._file_manager = MagicMock()
+        file_name = os.path.join(self.directory.value.return_value, self.file_name + ".csv")
+        records = self._get_records()
+
+        # Act
+        cm.to_csv_file(records)
+
+        # Assert
+        ((filename_used, record_lines_used), kwargs) = cm._file_manager.write_lines.call_args_list[0]
+        self.assertEqual(file_name, filename_used)
+        for r, l in zip(records, record_lines_used):
+            self.assertIn(r.to_csv_string(), l)
+
+    def test_make_image_dir_attempts_to_make_dir_if_it_does_not_exist(self):
+        # Arrange
+        cm = CommsManager(self.directory, self.file_name)
+        cm._file_manager = MagicMock()
+        cm._file_manager.is_dir.return_value = False
+        img_dir = os.path.join(self.directory.value.return_value, "img_dir")
+
+        # Act
+        cm.make_img_dir()
+
+        # Assert
+        cm._file_manager.is_dir.assert_called_once_with(img_dir)
+        cm._file_manager.make_dir.assert_called_once_with(img_dir)
+
+    def test_make_image_dir_doent_make_dir_if_it_does_not_exist(self):
+
+        # Arrange
+        cm = CommsManager(self.directory, self.file_name)
+        cm._file_manager = MagicMock()
+        cm._file_manager.is_dir.return_value = True
+        img_dir = os.path.join(self.directory.value.return_value, "img_dir")
+
+        # Act
+        cm.make_img_dir()
+
+        # Assert
+        cm._file_manager.is_dir.assert_called_once_with(img_dir)
+        cm._file_manager.make_dir.assert_not_called()
+
+    def test_remove_image_file_attempts_to_remove_file_when_it_exists(self):
+        # Arrange
+        cm = CommsManager(self.directory, self.file_name)
+        cm._file_manager = MagicMock()
+        cm._file_manager.is_file.return_value = True
+
+        # Act
+        cm.remove_img_file(MagicMock())
+
+        # Assert
+        cm._file_manager.remove.assert_called_once()
+
+    def test_remove_image_file_does_not_attempt_to_remove_file_when_it_exists(self):
+        # Arrange
+        cm = CommsManager(self.directory, self.file_name)
+        cm._file_manager = MagicMock()
+        cm._file_manager.is_file.return_value = False
+
+        # Act
+        cm.remove_img_file(MagicMock())
+
+        # Assert
+        cm._file_manager.remove.assert_not_called()
+
+
+    def _invalid_record_strings(self):
+        str_rep = list()
+        str_rep.append(ID0 + ";1494238925.0;test.png;None;DLSL-009,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
+        str_rep.append(ID1 + ";Invalid record string")
+        str_rep.append(ID2 + ";1494238921.0;test.png;None;DLSL-008,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
+        return str_rep
+
+    def _get_record_strings(self):
+        str_rep = list()
+        str_rep.append(ID0 + ";1494238923.0;test" + ID0 + ".png;None;DLSL-001,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
+        str_rep.append(ID1 + ";1494238922.0;test" + ID1 + ".png;None;DLSL-002,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
+        str_rep.append(ID2 + ";1494238921.0;test" + ID2 + ".png;None;DLSL-003,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
+        str_rep.append(ID3 + ";1494238920.0;test" + ID3 + ".png;None;DLSL-004,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
+        return str_rep
+
+    def _get_records(self):
+        strings = self._get_record_strings()
+        rep = list()
+        for str in strings:
+            rep.append(Record.from_string(str))
+        return rep
+
+
+
+

--- a/tests/unit_tests/test_dls_barcode/test_data_store/test_store.py
+++ b/tests/unit_tests/test_dls_barcode/test_data_store/test_store.py
@@ -3,6 +3,8 @@ from mock import MagicMock
 from mock import call
 import os
 from dls_barcode.data_store import Store
+from dls_barcode.data_store.record import Record
+from dls_barcode.data_store.store_manager import StoreManager
 
 ID0 = "id0"
 ID1 = "id1"
@@ -12,11 +14,10 @@ ID3 = "id3"
 class TestStore(unittest.TestCase):
 
     def setUp(self):
-        self._file_manager = MagicMock()
-        self._directory = "a_path"
-        self._expected_img_dir = os.path.join(self._directory, "img_dir")
-        self._expected_store_file = os.path.join(self._directory, "store.txt")
-        self._expected_csv_file = os.path.join(self._directory, "store.csv")
+        self._backup = MagicMock()
+        self._comms_manager = MagicMock()
+        self._comms_manager.make_img_dir.return_value = "img_dir"
+        self._expected_img_dir = "img_dir"
         self._store_capacity = MagicMock()
         self._store_capacity.value.return_value = 50
 
@@ -33,76 +34,50 @@ class TestStore(unittest.TestCase):
         self._plate.geometry.return_value = geometry
 
     def test_new_store_creates_image_directory_if_it_does_not_exist(self):
-        # Arrange
-        self._file_manager.is_dir.return_value = False
-        self._file_manager.is_file.return_value = False
-
         # Act
         self._create_store()
 
         # Assert
-        self._file_manager.make_dir.assert_called_once_with(self._expected_img_dir)
-
-    def test_new_store_has_no_records_if_store_file_does_not_exist(self):
-        # Arrange
-        self._file_manager.is_file.return_value = False
-
-        # Act
-        store = self._create_store()
-
-        # Assert
-        self.assertFalse(store.records)
-        self.assertEquals(store.size(), 0)
+        self._comms_manager.make_img_dir.assert_called()
 
     def test_new_store_loads_records_from_existing_store_file(self):
         # Arrange
-        record_strings = self._get_record_strings()
-        self._file_manager.read_lines.return_value = record_strings
+        records = self._get_records()
+        self._comms_manager.load_records_from_file.return_value = records
 
         # Act
         store = self._create_store()
 
         # Assert
-        self.assertEquals(len(store.records), len(record_strings))
-        self.assertEquals(store.size(), len(record_strings))
-        self.assertEquals(store.records[0].id, ID0)
-        self.assertEquals(store.records[1].id, ID1)
-        self.assertEquals(store.records[2].id, ID2)
-        self.assertEquals(store.records[3].id, ID3)
-
-    def test_new_store_skips_invalid_lines_when_loading_records_from_file(self):
-        # Arrange
-        self._file_manager.read_lines.return_value = self._invalid_record_strings()
-
-        # Act
-        store = self._create_store()
-
-        # Assert
-        self.assertEquals(len(store.records), 2)
-        self.assertEquals(store.records[0].id, ID0)
-        self.assertEquals(store.records[1].id, ID2)
+        self.assertEqual(len(store.records), len(records))
+        self.assertEqual(store.size(), len(records))
+        self.assertEqual(store.records[0].id, ID0)
+        self.assertEqual(store.records[1].id, ID1)
+        self.assertEqual(store.records[2].id, ID2)
+        self.assertEqual(store.records[3].id, ID3)
 
     def test_max_number_of_stored_records_is_the_store_capacity(self):
         # Arrange
-        record_strings = self._get_record_strings()
-        self._file_manager.read_lines.return_value = record_strings
+        records = self._get_records()
+        self._comms_manager.load_records_from_file.return_value = records
         expected_capacity = 3
         self._store_capacity.value.return_value = expected_capacity
 
-        self.assertLess(expected_capacity, len(record_strings))
+        self.assertLess(expected_capacity, len(records))
 
         # Act
         store = self._create_store()
 
         # Assert
-        self.assertEquals(len(store.records), expected_capacity)
-        self.assertEquals(store.records[0].id, ID0)
-        self.assertEquals(store.records[1].id, ID1)
-        self.assertEquals(store.records[2].id, ID2)
+        self.assertEqual(len(store.records), expected_capacity)
+        self.assertEqual(store.records[0].id, ID0)
+        self.assertEqual(store.records[1].id, ID1)
+        self.assertEqual(store.records[2].id, ID2)
 
     def test_minimum_store_capacity_is_2(self):
         # Arrange
-        self._file_manager.read_lines.return_value = self._get_record_strings()
+        records = self._get_records()
+        self._comms_manager.load_records_from_file.return_value = records
         expected_capacity = 2
         self._store_capacity.value.return_value = 1
 
@@ -110,11 +85,11 @@ class TestStore(unittest.TestCase):
         store = self._create_store()
 
         # Assert
-        self.assertEquals(len(store.records), expected_capacity)
+        self.assertEqual(len(store.records), expected_capacity)
 
     def test_new_store_has_records_sorted_most_recent_first(self):
         # Arrange
-        self._file_manager.read_lines.return_value = self._get_unordered_record_strings()
+        self._comms_manager.load_records_from_file.return_value = self._get_unordered_records()
 
         # Act
         store = self._create_store()
@@ -125,7 +100,7 @@ class TestStore(unittest.TestCase):
 
     def test_a_record_can_be_retrieved_by_index(self):
         # Arrange
-        self._file_manager.read_lines.return_value = self._get_record_strings()
+        self._comms_manager.load_records_from_file.return_value = self._get_records()
         store = self._create_store()
         index = 1
         expected_id = ID1
@@ -134,12 +109,13 @@ class TestStore(unittest.TestCase):
         r = store.get_record(index)
 
         # Assert
-        self.assertEquals(r.id, expected_id)
+        self.assertEqual(r.id, expected_id)
 
     def test_get_record_returns_None_if_store_is_empty(self):
         # Arrange
+        self._comms_manager.load_records_from_file.return_value = []
         store = self._create_store()
-        self.assertEquals(store.size(), 0)
+        self.assertEqual(store.size(), 0)
 
         # Act
         r = store.get_record(0)
@@ -162,6 +138,7 @@ class TestStore(unittest.TestCase):
 
     def test_given_an_empty_store_when_merging_a_record_then_the_record_is_added_to_the_store(self):
         # Arrange
+        self._comms_manager.load_records_from_file.return_value = []
         store = self._create_store()
         holder_barcode = "ABCD"
         old_store_size = store.size()
@@ -170,15 +147,15 @@ class TestStore(unittest.TestCase):
         store.merge_record(holder_barcode, self._plate, self._holder_img, self._pins_img)
 
         # Assert
-        self.assertEquals(store.size(), old_store_size + 1)
+        self.assertEqual(store.size(), old_store_size + 1)
         r = store.get_record(0)
-        self.assertEquals(r.holder_barcode, holder_barcode)
+        self.assertEqual(r.holder_barcode, holder_barcode)
 
     def test_given_a_non_empty_store_when_merging_a_record_with_different_holder_than_the_latest_record_then_the_new_record_is_added(self):
         # Arrange
         holder1_barcode = "AAA"
         rec_string = "f59c92c1;1494238920.0;test.png;None;" + holder1_barcode + ",DLSL-009,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68"
-        self._file_manager.read_lines.return_value = [rec_string]
+        self._comms_manager.load_records_from_file.return_value = [Record.from_string(rec_string)]
         store = self._create_store()
         old_store_size = store.size()
 
@@ -188,9 +165,9 @@ class TestStore(unittest.TestCase):
         store.merge_record(holder2_barcode, self._plate, self._holder_img, self._pins_img)
 
         # Assert
-        self.assertEquals(store.size(), old_store_size + 1)
-        self.assertEquals(store.records[0].holder_barcode, holder2_barcode)
-        self.assertEquals(store.records[1].holder_barcode, holder1_barcode)
+        self.assertEqual(store.size(), old_store_size + 1)
+        self.assertEqual(store.records[0].holder_barcode, holder2_barcode)
+        self.assertEqual(store.records[1].holder_barcode, holder1_barcode)
 
     def test_given_a_non_empty_store_when_merging_a_record_with_same_holder_to_the_latest_record_then_latest_record_is_replaced(self):
         # Arrange
@@ -198,7 +175,7 @@ class TestStore(unittest.TestCase):
         old_pin_barcode = "DLSL-009"
         new_pin_barcodes = ["DLSL-010"]
         rec_string = "f59c92c1;1494238920.0;test.png;None;" + holder_barcode + "," + old_pin_barcode + ";1569:1106:70-2307:1073:68-1944:1071:68"
-        self._file_manager.read_lines.return_value = [rec_string]
+        self._comms_manager.load_records_from_file.return_value = [Record.from_string(rec_string)]
         store = self._create_store()
         old_store_size = store.size()
 
@@ -208,18 +185,18 @@ class TestStore(unittest.TestCase):
         store.merge_record(holder_barcode, self._plate, self._holder_img, self._pins_img)
 
         # Assert
-        self.assertEquals(store.size(), old_store_size)
+        self.assertEqual(store.size(), old_store_size)
         r = store.records[0]
-        self.assertEquals(r.holder_barcode, holder_barcode)
+        self.assertEqual(r.holder_barcode, holder_barcode)
         self.assertListEqual(r.barcodes, new_pin_barcodes)
 
     def test_duplicate_holder_barcodes_are_allowed_if_the_duplicate_is_not_the_latest_record(self):
         # Arrange
         holder_barcode = "ABD1234"
-        rec_strings = self._get_record_strings()
+        recs = self._get_records()
         duplicate_rec_string = "f59c92c1;1494238900.0;test.png;None;" + holder_barcode + ",DLSL-009,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68"
-        rec_strings.append(duplicate_rec_string)
-        self._file_manager.read_lines.return_value = rec_strings
+        recs.append(Record.from_string(duplicate_rec_string))
+        self._comms_manager.load_records_from_file.return_value = recs
         store = self._create_store()
         old_store_size = store.size()
 
@@ -227,48 +204,42 @@ class TestStore(unittest.TestCase):
         store.merge_record(holder_barcode, self._plate, self._holder_img, self._pins_img)
 
         # Assert
-        self.assertEquals(store.size(), old_store_size + 1)
+        self.assertEqual(store.size(), old_store_size + 1)
         duplicates = [r for r in store.records if r.holder_barcode == holder_barcode]
-        self.assertEquals(len(duplicates), 2)
+        self.assertEqual(len(duplicates), 2)
 
     def test_given_a_store_when_merging_a_record_then_store_is_saved_to_backing_file(self):
         # Arrange
         store = self._create_store()
         holder_barcode = "ABAB"
-        self._file_manager.write_lines.assert_not_called()
+        self._comms_manager.to_file.assert_not_called()
 
         # Act
         store.merge_record(holder_barcode, self._plate, self._holder_img, self._pins_img)
 
         # Assert
-        self._file_manager.write_lines.assert_called()
-        ((filename_used, record_lines_used), kwargs) = self._file_manager.write_lines.call_args_list[0]
-        self.assertEquals(filename_used, self._expected_store_file)
-        self.assertIn(holder_barcode, record_lines_used[0])
+        self._comms_manager.to_file.assert_called()
 
     def test_given_a_store_when_merging_a_record_then_store_is_saved_to_csv_file(self):
         # Arrange
         store = self._create_store()
         holder_barcode = "HELLO"
-        self._file_manager.write_lines.assert_not_called()
+        self._comms_manager.to_csv_file.assert_not_called()
 
         # Act
         store.merge_record(holder_barcode, self._plate, self._holder_img, self._pins_img)
 
         # Assert
-        self._file_manager.write_lines.assert_called()
-        ((filename_used, record_lines_used), kwargs) = self._file_manager.write_lines.call_args_list[1]
-        self.assertEquals(filename_used, self._expected_csv_file)
-        self.assertIn(holder_barcode, record_lines_used[0])
+        self._comms_manager.to_csv_file.assert_called()
 
     def test_given_a_non_empty_store_of_size_equal_to_capacity_when_a_new_record_is_merged_then_oldest_record_is_deleted(self):
         # Arrange
         capacity = 4
         self._store_capacity.value.return_value = capacity
-        self._file_manager.read_lines.return_value = self._get_record_strings()
+        self._comms_manager.load_records_from_file.return_value = self._get_records()
         store = self._create_store()
         old_store_size = store.size()
-        self.assertEquals(old_store_size, capacity)
+        self.assertEqual(old_store_size, capacity)
         holder_barcode = "asd"
         oldest_record = store.records[-1]
 
@@ -276,14 +247,14 @@ class TestStore(unittest.TestCase):
         store.merge_record(holder_barcode, self._plate, self._holder_img, self._pins_img)
 
         # Assert
-        self.assertEquals(store.size(), old_store_size)
+        self.assertEqual(store.size(), old_store_size)
         latest_rec = store.get_record(0)
-        self.assertEquals(latest_rec.holder_barcode, holder_barcode)
+        self.assertEqual(latest_rec.holder_barcode, holder_barcode)
         self.assertNotIn(oldest_record, store.records)
 
     def test_multiple_records_can_be_deleted(self):
         # Arrange
-        self._file_manager.read_lines.return_value = self._get_record_strings()
+        self._comms_manager.load_records_from_file.return_value = self._get_records()
         store = self._create_store()
         old_store_size = store.size()
         records_to_delete =[r for r in store.records if r.id == ID1 or r.id == ID3]
@@ -293,73 +264,64 @@ class TestStore(unittest.TestCase):
         store.delete_records(records_to_delete)
 
         # Assert
-        self.assertEquals(store.size(), old_store_size - len(records_to_delete))
+        self.assertEqual(store.size(), old_store_size - len(records_to_delete))
         for r in records_to_delete:
             self.assertNotIn(r, store.records)
 
     def test_when_records_are_deleted_then_their_image_file_is_deleted_too(self):
         # Arrange
-        self._file_manager.read_lines.return_value = self._get_record_strings()
+        self._comms_manager.load_records_from_file.return_value = self._get_records()
         store = self._create_store()
         records_to_delete = [r for r in store.records if r.id == ID1 or r.id == ID3]
         self.assertTrue(records_to_delete)
-        self._file_manager.remove.assert_not_called()
+        self._comms_manager.remove_img_file.assert_not_called()
 
         expected_calls = []
         for r in records_to_delete:
-            expected_calls.append(call(r.image_path))
+            expected_calls.append(call(r))
 
         # Act
         store.delete_records(records_to_delete)
 
         # Assert
-        self._file_manager.remove.assert_has_calls(expected_calls)
+        self._comms_manager.remove_img_file.assert_has_calls(expected_calls)
 
     def test_when_records_are_deleted_then_store_file_is_updated(self):
         # Arrange
-        self._file_manager.read_lines.return_value = self._get_record_strings()
+        self._comms_manager.load_records_from_file.return_value = self._get_records()
         store = self._create_store()
         records_to_delete = [r for r in store.records if r.id == ID1 or r.id == ID3]
         self.assertTrue(records_to_delete)
-        self._file_manager.write_lines.assert_not_called()
+        self._comms_manager.to_file.assert_not_called()
 
         # Act
         store.delete_records(records_to_delete)
 
         # Assert
-        self._file_manager.write_lines.assert_called()
-        ((filename_used, record_lines_used), kwargs) = self._file_manager.write_lines.call_args_list[0]
-        self.assertEquals(filename_used, self._expected_store_file)
-        self.assertEquals(len(record_lines_used), store.size())
-        for r, l in zip(store.records, record_lines_used):
-            self.assertIn(r.to_string(), l)
+        self._comms_manager.to_file.assert_called()
+
 
     def test_when_records_are_deleted_then_csv_file_is_updated(self):
         # Arrange
-        self._file_manager.read_lines.return_value = self._get_record_strings()
+        self._comms_manager.load_records_from_file.return_value = self._get_records()
         store = self._create_store()
         records_to_delete = [r for r in store.records if r.id == ID1 or r.id == ID3]
         self.assertTrue(records_to_delete)
-        self._file_manager.write_lines.assert_not_called()
+        self._comms_manager.to_csv_file.assert_not_called()
 
         # Act
         store.delete_records(records_to_delete)
 
         # Assert
-        self._file_manager.write_lines.assert_called()
-        ((filename_used, record_lines_used), kwargs) = self._file_manager.write_lines.call_args_list[1]
-        self.assertEquals(filename_used, self._expected_csv_file)
-        self.assertEquals(len(record_lines_used), store.size())
-        for r, l in zip(store.records, record_lines_used):
-            self.assertIn(r.to_csv_string(), l)
+        self._comms_manager.to_csv_file.assert_called()
 
     def test_given_a_non_empty_store_when_capacity_is_reduced_then_records_are_truncated_at_next_merge(self):
         # Arrange
         old_capacity = 4
         self._store_capacity.value.return_value = old_capacity
-        self._file_manager.read_lines.return_value = self._get_record_strings()
+        self._comms_manager.load_records_from_file.return_value = self._get_records()
         store = self._create_store()
-        self.assertEquals(store.size(), old_capacity)
+        self.assertEqual(store.size(), old_capacity)
 
         new_capacity = 2
         self._store_capacity.value.return_value = new_capacity
@@ -371,9 +333,9 @@ class TestStore(unittest.TestCase):
         store.merge_record(holder_barcode, self._plate, self._holder_img, self._pins_img)
 
         # Assert
-        self.assertEquals(store.size(), new_capacity)
+        self.assertEqual(store.size(), new_capacity)
         latest_rec = store.get_record(0)
-        self.assertEquals(latest_rec.holder_barcode, holder_barcode)
+        self.assertEqual(latest_rec.holder_barcode, holder_barcode)
         for r in expected_truncated_records:
             self.assertNotIn(r, store.records)
 
@@ -381,9 +343,9 @@ class TestStore(unittest.TestCase):
         # Arrange
         old_capacity = 4
         self._store_capacity.value.return_value = old_capacity
-        self._file_manager.read_lines.return_value = self._get_record_strings()
+        self._comms_manager.load_records_from_file.return_value = self._get_records()
         store = self._create_store()
-        self.assertEquals(store.size(), old_capacity)
+        self.assertEqual(store.size(), old_capacity)
 
         new_capacity = 2
         self._store_capacity.value.return_value = new_capacity
@@ -394,12 +356,12 @@ class TestStore(unittest.TestCase):
         store.delete_records([record_to_delete])
 
         # Assert
-        self.assertEquals(store.size(), new_capacity)
+        self.assertEqual(store.size(), new_capacity)
         self.assertNotIn(record_to_delete, store.records)
         self.assertNotIn(expected_truncated_record, store.records)
 
     def _create_store(self):
-        return Store(self._directory, self._store_capacity, self._file_manager)
+        return Store(self._comms_manager, self._backup, self._store_capacity)
 
     def _get_record_strings(self):
         str_rep = list()
@@ -409,6 +371,13 @@ class TestStore(unittest.TestCase):
         str_rep.append(ID3 + ";1494238920.0;test" + ID3 + ".png;None;DLSL-004,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
         return str_rep
 
+    def _get_records(self):
+        strings = self._get_record_strings()
+        rep = list()
+        for str in strings:
+            rep.append(Record.from_string(str))
+        return rep
+
     def _get_unordered_record_strings(self):
         str_rep = list()
         str_rep.append(ID0 + ";1494238905.0;test" + ID0 + ".png;None;DLSL-001,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
@@ -417,10 +386,10 @@ class TestStore(unittest.TestCase):
         str_rep.append(ID3 + ";1494238930.0;test" + ID3 + ".png;None;DLSL-004,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
         return str_rep
 
-    def _invalid_record_strings(self):
-        str_rep = list()
-        str_rep.append(ID0 + ";1494238925.0;test.png;None;DLSL-009,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
-        str_rep.append(ID1 + ";Invalid record string")
-        str_rep.append(ID2 + ";1494238921.0;test.png;None;DLSL-008,DLSL-010,DLSL-011,DLSL-012;1569:1106:70-2307:1073:68-1944:1071:68")
-        return str_rep
+    def _get_unordered_records(self):
+        strings = self._get_unordered_record_strings()
+        rep = list()
+        for str in strings:
+            rep.append(Record.from_string(str))
+        return rep
 

--- a/tests/unit_tests/test_dls_barcode/test_data_store/test_store.py
+++ b/tests/unit_tests/test_dls_barcode/test_data_store/test_store.py
@@ -1,10 +1,8 @@
 import unittest
 from mock import MagicMock
 from mock import call
-import os
 from dls_barcode.data_store import Store
 from dls_barcode.data_store.record import Record
-from dls_barcode.data_store.store_manager import StoreManager
 
 ID0 = "id0"
 ID1 = "id1"
@@ -299,6 +297,10 @@ class TestStore(unittest.TestCase):
 
         # Assert
         self._comms_manager.to_file.assert_called()
+        ((record_lines_used), kwargs) = self._comms_manager.to_file.call_args_list[0]
+        self.assertEqual(len(record_lines_used[0]), store.size())
+        for r, l in zip(store.records, record_lines_used):
+            self.assertIn(r, l)
 
 
     def test_when_records_are_deleted_then_csv_file_is_updated(self):
@@ -314,6 +316,11 @@ class TestStore(unittest.TestCase):
 
         # Assert
         self._comms_manager.to_csv_file.assert_called()
+
+        ((record_lines_used), kwargs) = self._comms_manager.to_csv_file.call_args_list[0]
+        self.assertEqual(len(record_lines_used[0]), store.size())
+        for r, l in zip(store.records, record_lines_used):
+            self.assertIn(r, l)
 
     def test_given_a_non_empty_store_when_capacity_is_reduced_then_records_are_truncated_at_next_merge(self):
         # Arrange


### PR DESCRIPTION
Solves ticket
-------------
 I04_1-404: Puck scanner - add record backup 

Description of work
-------------------
I've added the the new record backup functionality.
When the delate button is pressed the records will be moved to a backup file (backup.csv created in the same folder as the store file).
Every record which was created ealier than a specified number of weeks will be automatically discarded from the backup list at the same time.
The number of weeks can be sepcified in the configuration of the porgram.

Housekeeping
------------
- [x] Code reviewed and tidied up

To test
-------
- [x] all automated tests pass
- [x] build still works and runs


Final steps
-----------
- [x] Added work to [development release notes](https://github.com/DiamondLightSource/PuckBarcodeReader/blob/master/docs/release-notes/release-notes-dev.md)
